### PR TITLE
Exit when the worker context is canceled

### DIFF
--- a/internal/workers/workers.go
+++ b/internal/workers/workers.go
@@ -71,11 +71,11 @@ func Run(ctx context.Context, config config.Config, executor jobs.HTTPJobExecuto
 	AssignmentPhaseLoop:
 		for {
 			select {
-			case <-ctx.Done():
+			case <-workerCtx.Done():
 				if cancelJobPoller != nil {
 					cancelJobPoller()
 				}
-				return ctx.Err()
+				return workerCtx.Err()
 			case nextReady := <-readinessPoller.next():
 				if nextReady != ready {
 					ready = nextReady
@@ -135,11 +135,11 @@ func Run(ctx context.Context, config config.Config, executor jobs.HTTPJobExecuto
 	ExecutePhaseLoop:
 		for {
 			select {
-			case <-ctx.Done():
+			case <-workerCtx.Done():
 				if cancelJobPoller != nil {
 					cancelJobPoller()
 				}
-				return ctx.Err()
+				return workerCtx.Err()
 			case nextReady := <-readinessPoller.next():
 				if nextReady != ready {
 					ready = nextReady


### PR DESCRIPTION
This appropriately exits the main loop after the worker context is canceled.