### PR TITLE
Add git tag and revision info to worker version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
+VERSION := $(shell git describe --exact-match --tags HEAD)
+ifeq ($(VERSION),)
+	VERSION := 'v0.0.0'
+endif
+VERSION_FLAGS := -X "github.com/saladtechnologies/salad-cloud-job-queue-worker/pkg/workers.Version=$(VERSION)"
+LDFLAGS := -ldflags='$(VERSION_FLAGS)'
+
 .PHONY: build
 build: clean
-	CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -o ./build/ ./cmd/salad-http-job-queue-worker
+	CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -o ./build/ $(LDFLAGS) ./cmd/salad-http-job-queue-worker
 	cd ./build; tar -czvf salad-http-job-queue-worker_x86_64.tar.gz salad-http-job-queue-worker
 	cd ./build; sha256sum salad-http-job-queue-worker_x86_64.tar.gz > salad-http-job-queue-worker_x86_64.tar.gz.sha256
 

--- a/cmd/salad-http-job-queue-worker/main.go
+++ b/cmd/salad-http-job-queue-worker/main.go
@@ -51,8 +51,8 @@ func main() {
 		cancel()
 	}()
 
-	logger.Info("starting SaladCloud Job Queue worker...")
 	w := workers.NewWorker(c, executeJob)
+	logger.Info("starting SaladCloud Job Queue worker...", "version", w.Version)
 	err = w.Run(log.WithLogger(ctx, logger))
 	if err != nil && !errors.Is(err, context.Canceled) {
 		defaultLogger.Error("failed to run SaladCloud Job Queue worker", "err", err)

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hcsshim v0.12.3 // indirect
+	github.com/carlmjohnson/versioninfo v0.22.5
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/containerd/containerd v1.7.17 // indirect
 	github.com/containerd/log v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/Microsoft/hcsshim v0.12.3 h1:LS9NXqXhMoqNCplK1ApmVSfB4UnVLRDWRapB6EIl
 github.com/Microsoft/hcsshim v0.12.3/go.mod h1:Iyl1WVpZzr+UkzjekHZbV8o5Z9ZkxNGx6CtY2Qg/JVQ=
 github.com/caarlos0/env/v11 v11.0.1 h1:A8dDt9Ub9ybqRSUF3fQc/TA/gTam2bKT4Pit+cwrsPs=
 github.com/caarlos0/env/v11 v11.0.1/go.mod h1:2RC3HQu8BQqtEK3V4iHPxj0jOdWdbPpWJ6pOueeU1xM=
+github.com/carlmjohnson/versioninfo v0.22.5 h1:O00sjOLUAFxYQjlN/bzYTuZiS0y6fWDQjMRvwtKgwwc=
+github.com/carlmjohnson/versioninfo v0.22.5/go.mod h1:QT9mph3wcVfISUKd0i9sZfVrPviHuSF+cUtLjm2WSf8=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cloudflare/backoff v0.0.0-20161212185259-647f3cdfc87a h1:8d1CEOF1xldesKds5tRG3tExBsMOgWYownMHNCsev54=

--- a/pkg/workers/workers.go
+++ b/pkg/workers/workers.go
@@ -2,16 +2,22 @@ package workers
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
+	"github.com/carlmjohnson/versioninfo"
 	"github.com/saladtechnologies/salad-cloud-job-queue-worker/internal/workers"
 	"github.com/saladtechnologies/salad-cloud-job-queue-worker/pkg/config"
 	"github.com/saladtechnologies/salad-cloud-job-queue-worker/pkg/jobs"
 )
 
+var Version = "v0.0.0"
+
 // Represents a worker bound to a SaladCloud job queue.
 type Worker struct {
 	config   config.Config
 	executor jobs.HTTPJobExecutor
+	Version  string
 }
 
 // Creates a new worker bound to a SaladCloud job queue. The worker will use the
@@ -20,6 +26,7 @@ func NewWorker(config config.Config, executor jobs.HTTPJobExecutor) *Worker {
 	return &Worker{
 		config:   config,
 		executor: executor,
+		Version:  fmt.Sprintf("%s+%s", strings.TrimPrefix(Version, "v"), versioninfo.Short()),
 	}
 }
 


### PR DESCRIPTION
This adds the git tag and revision info to the worker version and logs its value on worker startup.