### PR TITLE
Handle unknown gRPC errors

### DIFF
--- a/internal/workers/workers.go
+++ b/internal/workers/workers.go
@@ -409,6 +409,8 @@ func (p *jobPoller) poll(ctx context.Context) error {
 						case codes.Unauthenticated:
 							reauth = true
 							break ReceiveLoop
+						case codes.Unknown:
+							break ReceiveLoop
 						default:
 							logger.Error("failed to receive job", "error", err)
 							delay := time.NewTimer(2 * time.Minute)


### PR DESCRIPTION
Similar to #33, we've observed some workers occasionally "getting stuck" with _unknown_ gRPC status codes. The framework docs suggest this can happen in various scenarios- and it has been observed infrequently.

Similar to #33, this adds the appropriate case to handle unknown status codes and ensures we don't endlessly retry.