### PR TITLE
Updates to tagged version handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-VERSION := $(shell git describe --exact-match --tags HEAD)
+VERSION := $(shell git describe --exact-match --tags HEAD 2>/dev/null)
 ifeq ($(VERSION),)
-	VERSION := 'v0.0.0'
+	# Create a dev version: vX.Y.Z-dev
+	VERSION := $(addsuffix -dev,$(shell git describe --abbrev=0 --tags HEAD))
 endif
 VERSION_FLAGS := -X "github.com/saladtechnologies/salad-cloud-job-queue-worker/pkg/workers.Version=$(VERSION)"
 LDFLAGS := -ldflags='$(VERSION_FLAGS)'

--- a/cmd/salad-http-job-queue-worker/main.go
+++ b/cmd/salad-http-job-queue-worker/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"log/slog"
@@ -18,7 +19,19 @@ import (
 	"github.com/saladtechnologies/salad-cloud-job-queue-worker/pkg/workers"
 )
 
+var VerFlag bool
+
+func init() {
+	flag.BoolVar(&VerFlag, "version", false, "Show version info")
+}
+
 func main() {
+	flag.Parse()
+	if VerFlag {
+		fmt.Printf("Version: %s\n", workers.VersionStr())
+		os.Exit(0)
+	}
+
 	defaultLogger := slog.Default()
 	c, err := config.NewConfigFromEnv()
 	if err != nil {

--- a/pkg/workers/workers.go
+++ b/pkg/workers/workers.go
@@ -3,9 +3,9 @@ package workers
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"strings"
 
-	"github.com/carlmjohnson/versioninfo"
 	"github.com/saladtechnologies/salad-cloud-job-queue-worker/internal/workers"
 	"github.com/saladtechnologies/salad-cloud-job-queue-worker/pkg/config"
 	"github.com/saladtechnologies/salad-cloud-job-queue-worker/pkg/jobs"
@@ -26,11 +26,33 @@ func NewWorker(config config.Config, executor jobs.HTTPJobExecutor) *Worker {
 	return &Worker{
 		config:   config,
 		executor: executor,
-		Version:  fmt.Sprintf("%s+%s", strings.TrimPrefix(Version, "v"), versioninfo.Short()),
+		Version:  VersionStr(),
 	}
 }
 
 // Runs the worker until the given context is cancelled.
 func (w *Worker) Run(ctx context.Context) error {
 	return workers.Run(ctx, w.config, w.executor, w.Version)
+}
+
+// Formats a complete version string
+func VersionStr() string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return fmt.Sprintf("%s", strings.TrimPrefix(Version, "v"))
+	}
+	var commit string
+	var modified string
+	for _, kv := range bi.Settings {
+		if kv.Key == "vcs.revision" {
+			commit = kv.Value
+			if len(commit) > 7 {
+				commit = commit[:7]
+			}
+		}
+		if kv.Key == "vcs.modified" {
+			modified = "-dirty"
+		}
+	}
+	return fmt.Sprintf("%s+%s%s", strings.TrimPrefix(Version, "v"), commit, modified)
 }


### PR DESCRIPTION
* Loosen version tag found in Makefile: --exact-match failed when not on a version tag showing v0.0.0, without it we get the most recent version tag followed by a commit-ish to indicate a modified build but also its base version
* Show version from command line with --version
* Eliminate the dependency on github.com/earthboundkid/versioninfo and get the vcs.revision value directly since the minimum go version is 1.21.