### PR TITLE
Use library version in User-Agent request header

### DIFF
--- a/internal/workers/grpc.go
+++ b/internal/workers/grpc.go
@@ -14,9 +14,7 @@ import (
 )
 
 // Creates a connection to the SaladCloud Job Queues service.
-func newQueueConnection(ctx context.Context, addr string, useTLS bool) (*grpc.ClientConn, error) {
-	// TODO: Use git version.
-	var version = "0.0.0"
+func newQueueConnection(ctx context.Context, addr string, useTLS bool, version string) (*grpc.ClientConn, error) {
 	var userAgent = fmt.Sprintf("salad-cloud-job-queue-worker/%s grpc-go/%s", version, grpc.Version)
 	opts := []grpc.DialOption{grpc.WithUserAgent(userAgent)}
 	if useTLS {

--- a/internal/workers/workers.go
+++ b/internal/workers/workers.go
@@ -25,7 +25,7 @@ var workloadInstanceNotFound = errors.New("workload instance not found")
 var jobNotFound = errors.New("job not found")
 var outputInvalid = errors.New("job output invalid")
 
-func Run(ctx context.Context, config config.Config, executor jobs.HTTPJobExecutor) error {
+func Run(ctx context.Context, config config.Config, executor jobs.HTTPJobExecutor, version string) error {
 	logger := log.FromContext(ctx)
 	workerCtx, cancelWorker := context.WithCancel(ctx)
 	defer cancelWorker()
@@ -35,7 +35,7 @@ func Run(ctx context.Context, config config.Config, executor jobs.HTTPJobExecuto
 		return err
 	}
 
-	conn, err := newQueueConnection(workerCtx, config.ServiceEndpoint, config.ServiceUseTLS)
+	conn, err := newQueueConnection(workerCtx, config.ServiceEndpoint, config.ServiceUseTLS, version)
 	if err != nil {
 		return err
 	}

--- a/pkg/workers/workers.go
+++ b/pkg/workers/workers.go
@@ -32,5 +32,5 @@ func NewWorker(config config.Config, executor jobs.HTTPJobExecutor) *Worker {
 
 // Runs the worker until the given context is cancelled.
 func (w *Worker) Run(ctx context.Context) error {
-	return workers.Run(ctx, w.config, w.executor)
+	return workers.Run(ctx, w.config, w.executor, w.Version)
 }


### PR DESCRIPTION
This passes the library version to the gRPC client and adds it to the User-Agent request header. This will be used in the near future by Job Queues to notify customers when an old version of the worker is still being used and whether there are any operational risks.