### PR TITLE
Restart AcceptJobs streams after an error

### DIFF
--- a/internal/workers/grpc.go
+++ b/internal/workers/grpc.go
@@ -31,7 +31,7 @@ func newQueueConnection(ctx context.Context, addr string, useTLS bool, version s
 				"name": [{"service": "salad.grpc.saladcloud_job_queue_worker.v1alpha.JobQueueWorkerService"}],
 				"retryPolicy": {
 					"MaxAttempts": 5,
-					"RetryableStatusCodes": ["UNKNOWN", "UNAVAILABLE"]
+					"RetryableStatusCodes": ["UNKNOWN", "INTERNAL", "UNAVAILABLE"]
 				},
 				"timeout": "30s",
 				"waitForReady": true
@@ -40,7 +40,7 @@ func newQueueConnection(ctx context.Context, addr string, useTLS bool, version s
 				"name": [{"service": "salad.grpc.saladcloud_job_queue_worker.v1alpha.JobQueueWorkerService", "method": "AcceptJobs"}],
 				"retryPolicy": {
 					"MaxAttempts": 5,
-					"RetryableStatusCodes": ["UNKNOWN", "UNAVAILABLE"]
+					"RetryableStatusCodes": ["UNKNOWN", "INTERNAL", "UNAVAILABLE"]
 				},
 				"timeout": null,
 				"waitForReady": true

--- a/internal/workers/workers.go
+++ b/internal/workers/workers.go
@@ -399,8 +399,6 @@ func (p *jobPoller) poll(ctx context.Context) error {
 						switch stat.Code() {
 						case codes.Canceled:
 							return ctx.Err()
-						case codes.Internal:
-							break ReceiveLoop
 						case codes.NotFound:
 							return jobNotFound
 						case codes.PermissionDenied:
@@ -409,18 +407,9 @@ func (p *jobPoller) poll(ctx context.Context) error {
 						case codes.Unauthenticated:
 							reauth = true
 							break ReceiveLoop
-						case codes.Unknown:
-							break ReceiveLoop
 						default:
 							logger.Error("failed to receive job", "error", err)
-							delay := time.NewTimer(2 * time.Minute)
-							select {
-							case <-ctx.Done():
-								delay.Stop()
-								return ctx.Err()
-							case <-delay.C:
-								continue
-							}
+							break ReceiveLoop
 						}
 					}
 				}


### PR DESCRIPTION
This improves the AcceptJobs stream error handling to ensure the stream is restarted after any error. Previously, the worker could get "stuck" in a never-ending loop on errors with certain, infrequent gRPC status codes.