### PR TITLE
Call RejectJob if the output is larger than the allowable limit

### DIFF
--- a/internal/workers/workers.go
+++ b/internal/workers/workers.go
@@ -573,6 +573,8 @@ func (h *jobHandler) complete(ctx context.Context, responseBody []byte) error {
 				return nil
 			case codes.PermissionDenied:
 				reauth = true
+			case codes.ResourceExhausted:
+				return outputInvalid
 			case codes.Unauthenticated:
 				reauth = true
 			default:


### PR DESCRIPTION
A call to CompleteJob may fail if the job output is larger than the allowable limit (currently about 20 MB). If that happens, this calls RejectJob so that we can move on to the next job.