### PR TITLE
Update Mandelbrot sample

### DIFF
--- a/samples/mandelbrot/base/Dockerfile
+++ b/samples/mandelbrot/base/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.12.7-slim-bookworm
+FROM python:3.13.0-slim-bookworm
 
 EXPOSE 80/tcp
 

--- a/samples/mandelbrot/base/requirements.txt
+++ b/samples/mandelbrot/base/requirements.txt
@@ -1,2 +1,2 @@
-fastapi[standard]==0.115.0
+fastapi[standard]==0.115.4
 matplotlib==3.9.2

--- a/samples/mandelbrot/with-s6-overlay/Dockerfile
+++ b/samples/mandelbrot/with-s6-overlay/Dockerfile
@@ -4,8 +4,8 @@ FROM mandelbrot:latest
 
 WORKDIR /app
 
-ARG SALAD_JOB_QUEUE_WORKER_VERSION=0.4.0
-ARG S6_OVERLAY_VERSION=3.2.0.0
+ARG SALAD_JOB_QUEUE_WORKER_VERSION=0.4.1
+ARG S6_OVERLAY_VERSION=3.2.0.2
 ENV S6_KEEP_ENV=1
 
 RUN apt-get update && \
@@ -18,7 +18,7 @@ RUN tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz && \
 ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-x86_64.tar.xz /tmp
 RUN tar -C / -Jxpf /tmp/s6-overlay-x86_64.tar.xz && \
     rm -rf /tmp/s6-overlay-x86_64.tar.xz
-ADD https://github.com/SaladTechnologies/salad-cloud-job-queue-worker/releases/download/${SALAD_JOB_QUEUE_WORKER_VERSION}/salad-http-job-queue-worker_x86_64.tar.gz /tmp
+ADD https://github.com/SaladTechnologies/salad-cloud-job-queue-worker/releases/download/v${SALAD_JOB_QUEUE_WORKER_VERSION}/salad-http-job-queue-worker_x86_64.tar.gz /tmp
 RUN tar -C /usr/local/bin -zxpf /tmp/salad-http-job-queue-worker_x86_64.tar.gz && \
     rm -rf /tmp/salad-http-job-queue-worker_x86_64.tar.gz
 

--- a/samples/mandelbrot/with-shell-script/Dockerfile
+++ b/samples/mandelbrot/with-shell-script/Dockerfile
@@ -4,12 +4,12 @@ FROM mandelbrot:latest
 
 WORKDIR /app
 
-ARG SALAD_JOB_QUEUE_WORKER_VERSION=0.4.0
+ARG SALAD_JOB_QUEUE_WORKER_VERSION=0.4.1
 RUN apt-get update && \
     apt-get -y install curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-ADD https://github.com/SaladTechnologies/salad-cloud-job-queue-worker/releases/download/${SALAD_JOB_QUEUE_WORKER_VERSION}/salad-http-job-queue-worker_x86_64.tar.gz /tmp
+ADD https://github.com/SaladTechnologies/salad-cloud-job-queue-worker/releases/download/v${SALAD_JOB_QUEUE_WORKER_VERSION}/salad-http-job-queue-worker_x86_64.tar.gz /tmp
 RUN tar -C /usr/local/bin -zxpf /tmp/salad-http-job-queue-worker_x86_64.tar.gz && \
     rm -rf /tmp/salad-http-job-queue-worker_x86_64.tar.gz
 


### PR DESCRIPTION
Updates the Mandelbrot sample to use the latest HTTP Job Queue Worker and the latest dependencies.