### PR TITLE
Create environment variable to set gRPC message size limit

### DIFF
--- a/internal/workers/grpc.go
+++ b/internal/workers/grpc.go
@@ -14,9 +14,15 @@ import (
 )
 
 // Creates a connection to the SaladCloud Job Queues service.
-func newQueueConnection(ctx context.Context, addr string, useTLS bool, version string) (*grpc.ClientConn, error) {
+func newQueueConnection(ctx context.Context, addr string, useTLS bool, maxMsgSize int, version string) (*grpc.ClientConn, error) {
 	var userAgent = fmt.Sprintf("salad-cloud-job-queue-worker/%s grpc-go/%s", version, grpc.Version)
-	opts := []grpc.DialOption{grpc.WithUserAgent(userAgent)}
+	opts := []grpc.DialOption{
+		grpc.WithUserAgent(userAgent),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(maxMsgSize),
+			grpc.MaxCallSendMsgSize(maxMsgSize),
+		),
+	}
 	if useTLS {
 		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
 			InsecureSkipVerify: false,

--- a/internal/workers/workers.go
+++ b/internal/workers/workers.go
@@ -31,7 +31,7 @@ func Run(ctx context.Context, config config.Config, executor jobs.HTTPJobExecuto
 	defer cancelWorker()
 
 	client := newMetadataClient(config.MetadataURI)
-	conn, err := newQueueConnection(workerCtx, config.ServiceEndpoint, config.ServiceUseTLS, version)
+	conn, err := newQueueConnection(workerCtx, config.ServiceEndpoint, config.ServiceUseTLS, config.GrpcMaxMessageSize, version)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,10 +6,11 @@ import (
 
 // TODO: Add option as an env var to include metadata in HTTP request body.
 type Config struct {
-	LogLevel        string `env:"SALAD_LOG_LEVEL" envDefault:"error"`
-	MetadataURI     string `env:"SALAD_METADATA_URI" envDefault:"http://169.254.169.254:80"`
-	ServiceEndpoint string `env:"SALAD_SERVICE_ENDPOINT" envDefault:"job-queue-worker-api.salad.com:443"`
-	ServiceUseTLS   bool   `env:"SALAD_SERVICE_USE_TLS" envDefault:"true"`
+	LogLevel           string `env:"SALAD_LOG_LEVEL" envDefault:"error"`
+	MetadataURI        string `env:"SALAD_METADATA_URI" envDefault:"http://169.254.169.254:80"`
+	ServiceEndpoint    string `env:"SALAD_SERVICE_ENDPOINT" envDefault:"job-queue-worker-api.salad.com:443"`
+	ServiceUseTLS      bool   `env:"SALAD_SERVICE_USE_TLS" envDefault:"true"`
+	GrpcMaxMessageSize int    `env:"SALAD_GRPC_MAX_MESSAGE_SIZE" envDefault:"11534336"`
 }
 
 func NewConfigFromEnv() (Config, error) {


### PR DESCRIPTION
This pull request introduces a configurable maximum gRPC message size for job queue workers, enhancing the flexibility and reliability of message handling. The changes allow the maximum message size to be set via environment variables and ensure this value is passed through the worker initialization and gRPC connection setup.

Configuration enhancements:

* Added a new `GrpcMaxMessageSize` field to the `Config` struct, allowing the maximum gRPC message size to be set via the `SALAD_GRPC_MAX_MESSAGE_SIZE` environment variable. (`pkg/config/config.go`)

Worker initialization improvements:

* Updated the worker initialization in `Run` to pass the `GrpcMaxMessageSize` from the configuration to the gRPC connection setup. (`internal/workers/workers.go`)

gRPC connection setup:

* Modified `newQueueConnection` to accept `maxMsgSize` and set both receive and send maximum message sizes using `grpc.WithDefaultCallOptions`. (`internal/workers/grpc.go`)
